### PR TITLE
Refresh LLMEO README and DeepSeek setup

### DIFF
--- a/config/models.template.yaml
+++ b/config/models.template.yaml
@@ -67,6 +67,16 @@ deepseek/deepseek-chat:
   model: deepseek-chat
   credentials: deepseek
 
+deepseek/deepseek-v4-flash:
+  provider: deepseek
+  model: deepseek-v4-flash
+  credentials: deepseek
+  __call_args:
+    thinking:
+      type: disabled
+    allowed_openai_params:
+      - thinking
+
 # Benchmark comparison models (gpt-5-chat, gpt-5, deepseek-R1, claude-sonnet-4.5)
 openai/gpt-5-chat:
   provider: openai

--- a/projects/llmeo/README.md
+++ b/projects/llmeo/README.md
@@ -7,31 +7,63 @@
 
 ## 📦 Install
 
-1. Get to the Project folder:
-   ```bash
-   cd projects/llmeo
-   ```
+Run these commands from the harness root unless a step says otherwise.
 
-2. Set Your API KEY:
-   ```bash
-   export OPENAI_API_KEY="your-api-key-here"
-   ```
+### 1. Enter the LLMEO project folder
 
-3. Download required dataset:
-   ```bash
-   wget https://zenodo.org/records/14328055/files/ground_truth_fitness_values.csv -P data/
-   ```
+```bash
+cd projects/llmeo
+```
 
-4. Set conda env:
-   ```bash
-   conda env create -f environment.yml
-   conda activate ScienceBench_LLMEO
-   ```
+### 2. Download required dataset
 
-5. (Optional) Run Test File:
-   ```bash
-   python test.py
-   ```
+```bash
+wget https://zenodo.org/records/14328055/files/ground_truth_fitness_values.csv -P data/
+```
+
+### 3. Set up the conda environment
+
+```bash
+conda env create -f environment.yml
+conda activate ScienceBench_LLMEO
+```
+
+### 4. Configure model files in the harness root
+
+```bash
+cd ../..
+
+cat > models.yaml <<'EOF'
+deepseek/deepseek-v4-flash:
+  provider: deepseek
+  model: deepseek-v4-flash
+  credentials: deepseek
+  __call_args:
+    thinking:
+      type: disabled
+    allowed_openai_params:
+      - thinking
+
+deepseek/deepseek-chat:
+  provider: deepseek
+  model: deepseek-chat
+  credentials: deepseek
+EOF
+
+cat > credentials.yaml <<'EOF'
+deepseek:
+  api_key: ${DEEPSEEK_API_KEY}
+EOF
+
+export DEEPSEEK_API_KEY="your-api-key-here"
+cd projects/llmeo
+```
+
+### 5. Optional legacy test file
+
+```bash
+python test.py
+```
 
 ## 🎯 Usage
 
@@ -81,12 +113,35 @@ python cli.py few-shot --help
 
 All modes support the following parameters:
 
-- `--api-key`: OpenAI API key
 - `--samples`: Initial sample number (default: 10)
 - `--num-samples`: Generated sample number (default: 10)
-- `--max-tokens`: Maximum token number (default: 5000)
-- `--temperature`: Temperature parameter (default: 0.0)
+- `--max-tokens`: Maximum token number (default: 8000)
+- `--iterations`: Iteration number (default: 2)
+- `--model`: Model name from the harness root `models.yaml` (default: `deepseek/deepseek-v4-flash`)
+- `--temperature`: Temperature parameter (default: 1.0)
 - `--seed`: Random seed (default: 42)
+
+### Verified Smoke Test
+
+After completing the setup above, run a minimal one-iteration check:
+
+```bash
+python cli.py few-shot \
+  --iterations 1 \
+  --samples 1 \
+  --num-samples 1 \
+  --temperature 0
+```
+
+The command should validate the data files, generate a response, evaluate `top10_avg_gap`, and print a final score in the terminal. A score of `0` is possible for this tiny smoke test and does not indicate a runtime failure.
+
+### Output
+
+The current CLI prints evaluation results to stdout. The final line has the form:
+
+```text
+✅ Few-Shot mode completed! Final score: {'top10_avg_gap': ...}
+```
 
 ## 🏗️ Project Structure
 
@@ -99,14 +154,13 @@ projects/llmeo/
 │   │   ├── few_shot.py     # Few-shot learning mode
 │   │   ├── single_prop.py  # Single property optimization mode
 │   │   └── multi_prop.py   # Multi-property optimization mode
+│   ├── weave_utils.py  # Weave logging helpers
 │   ├── utils/          # Utility modules
 │   │   ├── __init__.py
 │   │   ├── data_loader.py  # Data loading utilities
 │   │   ├── prompt.py       # Prompt templates
 │   │   └── _utils.py       # Utility functions
-│   └── evaluators/     # Evaluation modules
 ├── data/               # Data files
-├── docs/               # Documentation
 ├── tests/              # Test files
 │   ├── __init__.py
 │   ├── conftest.py
@@ -122,59 +176,13 @@ projects/llmeo/
 └── README.md           # This document
 ```
 
-## 🔧 Extension Development
-
-### Adding New Running Modes
-
-1. Create a new mode file in the `src/modes/` directory
-2. Implement the mode function, e.g., `run_new_mode(args)`
-3. Import the new function in `src/modes/__init__.py`
-4. Add new subcommand in `cli.py`
-
-Example:
-
-```python
-# src/modes/new_mode.py
-def run_new_mode(args):
-    """Logic for running new mode"""
-    print("🆕 Running new mode...")
-    # Implement specific logic
-    return result
-
-# Add in cli.py
-new_mode_parser = subparsers.add_parser(
-    'new-mode', 
-    parents=[common_args],
-    help='New mode description'
-)
-```
-
-### Custom Configuration
-
-You can customize settings through configuration files:
-
-```json
-{
-  "api": {
-    "openai_api_key": "your-key"
-  },
-  "generation": {
-    "max_tokens": 3000,
-    "temperature": 0.1
-  },
-  "workflow": {
-    "max_iterations": 5
-  }
-}
-```
-
 ## 🐛 Troubleshooting
 
 ### Common Issues
 
 1. **API Key Error**
    ```bash
-   export OPENAI_API_KEY="your-actual-key"
+   export DEEPSEEK_API_KEY="your-actual-key"
    ```
 
 2. **Missing Data Files**
@@ -193,13 +201,23 @@ You can customize settings through configuration files:
    conda activate ScienceBench_LLMEO
    ```
 
-### Debug Mode
+4. **Weave Login / Logging Issues**
 
-Enable detailed logging:
+   LLMEO disables Weave network logging by default so local checks do not require a Weights & Biases account or network access. To enable Weave logging for a real run:
+   ```bash
+   LLMEO_ENABLE_WEAVE=true python cli.py few-shot --iterations 1 --samples 1 --num-samples 1
+   ```
 
-```bash
-python cli.py few-shot --debug
-```
+5. **Legacy Model Alias**
+
+   `deepseek/deepseek-chat` is kept in the example config for old runs, but the default is `deepseek/deepseek-v4-flash`.
+   ```bash
+   python cli.py few-shot --model deepseek/deepseek-v4-flash
+   ```
+
+6. **DeepSeek V4-Flash Empty Output**
+
+   DeepSeek V4-Flash enables thinking mode by default. For this project, keep the `thinking: disabled` and `allowed_openai_params` entries shown above in `models.yaml`; otherwise the model may spend the full token budget on reasoning and return empty visible content.
 
 ## 📚 Examples
 
@@ -207,7 +225,7 @@ python cli.py few-shot --debug
 
 ```bash
 # 1. Set up environment
-export OPENAI_API_KEY="your-key"
+export DEEPSEEK_API_KEY="your-key"
 cd projects/llmeo
 
 # 2. Run Few-shot mode
@@ -238,4 +256,3 @@ This project is based on the original LLMEO project and follows the correspondin
 
 - Original code repository: [https://github.com/deepprinciple/llmeo](https://github.com/deepprinciple/llmeo)
 - Reference project cli: [https://github.com/schwallergroup/steer](https://github.com/schwallergroup/steer)
-    

--- a/projects/llmeo/cli.py
+++ b/projects/llmeo/cli.py
@@ -7,7 +7,6 @@ Command Line Interface for scientific discovery workflows.
 import argparse
 import sys
 import os
-from typing import Optional
 
 # Add project root to Python path
 project_root = os.path.dirname(
@@ -15,9 +14,45 @@ project_root = os.path.dirname(
 )
 sys.path.insert(0, project_root)
 
-# Import local modules
-from src.modes import run_few_shot, run_single_prop, run_multi_prop
-from src.utils.data_loader import validate_data_files
+validate_data_files = None
+run_few_shot = None
+run_single_prop = None
+run_multi_prop = None
+
+
+def get_validate_data_files():
+    """Load data validation only for commands that actually run a mode."""
+    global validate_data_files
+
+    if validate_data_files is None:
+        from src.utils.data_loader import validate_data_files as loaded_validator
+        validate_data_files = loaded_validator
+    return validate_data_files
+
+
+def get_mode_runner(mode: str):
+    """Load mode implementations only after CLI parsing."""
+    global run_few_shot, run_single_prop, run_multi_prop
+
+    if mode == "few-shot":
+        if run_few_shot is None:
+            from src.modes import run_few_shot as loaded_runner
+            run_few_shot = loaded_runner
+        return run_few_shot
+
+    if mode == "single-prop":
+        if run_single_prop is None:
+            from src.modes import run_single_prop as loaded_runner
+            run_single_prop = loaded_runner
+        return run_single_prop
+
+    if mode == "multi-prop":
+        if run_multi_prop is None:
+            from src.modes import run_multi_prop as loaded_runner
+            run_multi_prop = loaded_runner
+        return run_multi_prop
+
+    raise ValueError(f"Unknown mode: {mode}")
 
 
 def main():
@@ -30,7 +65,6 @@ Example usage:
   python cli.py few-shot --iterations 3 --temperature 0.1
   python cli.py multi-prop --max-tokens 5000 --samples 20
   python cli.py single-prop --num-samples 15
-  python cli.py diy-gen --temperature 0.8
         """,
     )
 
@@ -44,7 +78,7 @@ Example usage:
     common_args.add_argument("--max-tokens", type=int, default=8000, help="Maximum token number (default: 8000)")
     common_args.add_argument("--iterations", type=int, default=2, help="Iteration number (default: 2)")
     common_args.add_argument("--seed", type=int, default=42, help="Random seed (default: 42)")
-    common_args.add_argument("--model", type=str, default="deepseek/deepseek-chat", help="Choose From [openai/gpt-4o-2024-08-06, anthropic/claude-3-7-sonnet-20250219, deepseek/deepseek-chat]")
+    common_args.add_argument("--model", type=str, default="deepseek/deepseek-v4-flash", help="Model name from the harness root models.yaml")
     common_args.add_argument("--temperature", type=float, default=1, help="Temperature")
     # Few-shot mode
     few_shot_parser = subparsers.add_parser(
@@ -70,18 +104,20 @@ Example usage:
 
 
     # Validate data files
-    if not validate_data_files():
+    if not get_validate_data_files()():
         sys.exit(1)
 
     # Run corresponding mode
     try:
+        runner = get_mode_runner(args.mode)
+
         if args.mode == "few-shot":
             print(args)
-            run_few_shot(args)
+            runner(args)
         elif args.mode == "single-prop":
-            run_single_prop(args)
+            runner(args)
         elif args.mode == "multi-prop":
-            run_multi_prop(args)
+            runner(args)
         else:
             print(f"❌ Unknown mode: {args.mode}")
             sys.exit(1)

--- a/projects/llmeo/environment.yml
+++ b/projects/llmeo/environment.yml
@@ -17,6 +17,9 @@ dependencies:
   - httpx=0.28.1
   - pip:
     - torch
-    - transformers
+    - transformers==4.53.0
+    - tokenizers==0.21.0
+    - litellm==1.73.6.post1
+    - weave>=0.51.54
     - molsimplify==1.7.5
     - git+https://github.com/hkneiding/uxtbpy

--- a/projects/llmeo/src/modes/few_shot.py
+++ b/projects/llmeo/src/modes/few_shot.py
@@ -8,6 +8,9 @@ import sys
 import os
 from typing import Any, Dict
 
+from ..weave_utils import configure_weave, safe_weave_init
+
+configure_weave()
 import weave
 
 # Add project root to Python path
@@ -38,7 +41,7 @@ def run_few_shot(args) -> Dict[str, Any]:
         Workflow execution result
     """
     print("🚀 Run Few-Shot learning mode...")
-    weave.init("few_shot_mode")
+    safe_weave_init(weave, "few_shot_mode")
     # Setup components
     generator = Generation(models_file=project_root + "/models.yaml", credentials_file=project_root + "/credentials.yaml")
 

--- a/projects/llmeo/src/modes/multi_prop.py
+++ b/projects/llmeo/src/modes/multi_prop.py
@@ -8,6 +8,9 @@ import sys
 import os
 from typing import Any, Dict
 
+from ..weave_utils import configure_weave, safe_weave_init
+
+configure_weave()
 import weave
 
 # Add project root to Python path
@@ -40,7 +43,7 @@ def run_multi_prop(args) -> Dict[str, Any]:
     print("🔄 Run multi-property optimization mode...")
 
     # Setup components
-    weave.init("LLMEO-multi_prop_mode")
+    safe_weave_init(weave, "LLMEO-multi_prop_mode")
     generator = Generation(models_file=project_root + "/models.yaml", credentials_file=project_root + "/credentials.yaml")
     # Load data
     with open("data/1M-space_50-ligands-full.csv", "r") as fo:

--- a/projects/llmeo/src/modes/single_prop.py
+++ b/projects/llmeo/src/modes/single_prop.py
@@ -8,6 +8,9 @@ import sys
 import os
 from typing import Any, Dict
 
+from ..weave_utils import configure_weave, safe_weave_init
+
+configure_weave()
 import weave
 
 # Add project root to Python path
@@ -38,7 +41,7 @@ def run_single_prop(args) -> Dict[str, Any]:
         Workflow execution result
     """
     print("🎯 Run single property optimization mode...")
-    weave.init("LLMEO-single-prop")
+    safe_weave_init(weave, "LLMEO-single-prop")
     # Setup components
     generator = Generation(models_file=project_root + "/models.yaml", credentials_file=project_root + "/credentials.yaml")
 

--- a/projects/llmeo/src/weave_utils.py
+++ b/projects/llmeo/src/weave_utils.py
@@ -1,0 +1,26 @@
+"""Weave initialization helpers for local LLMEO runs."""
+
+import os
+from typing import Any
+
+
+def configure_weave() -> None:
+    """Disable Weave network logging by default for reproducible local runs."""
+    enable_weave = os.getenv("LLMEO_ENABLE_WEAVE", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    if enable_weave:
+        os.environ.pop("WEAVE_DISABLED", None)
+    else:
+        os.environ.setdefault("WEAVE_DISABLED", "true")
+
+
+def safe_weave_init(weave_module: Any, project_name: str) -> None:
+    """Initialize Weave when available, but do not fail the run if it is offline."""
+    try:
+        weave_module.init(project_name)
+    except Exception as exc:
+        print(f"Weave init skipped: {exc.__class__.__name__}: {exc}")

--- a/projects/llmeo/test.py
+++ b/projects/llmeo/test.py
@@ -14,14 +14,17 @@ import pandas as pd
 from unittest.mock import patch, MagicMock
 import sys
 import os
-import weave
+from pathlib import Path
 
 
 # Add project root to Python path
-project_root = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-)
+project_root = str(Path(__file__).resolve().parents[2])
 sys.path.insert(0, project_root)
+
+from src.weave_utils import configure_weave, safe_weave_init
+
+configure_weave()
+import weave
 
 from src.utils._utils import (
     make_text_for_existing_tmcs,
@@ -37,19 +40,19 @@ class TestUtils(unittest.TestCase):
 
     def test_Generation(self):
         """Test Generation class"""
-        weave.init("LLMEO-test")
+        safe_weave_init(weave, "LLMEO-test")
         gen = Generation(models_file=project_root + "/models.yaml", credentials_file=project_root + "/credentials.yaml")
         self.assertIsNotNone(gen)
     
     def test_model(self):
         """Test model"""
-        weave.init("LLMEO-test")
+        safe_weave_init(weave, "LLMEO-test")
         gen = Generation(models_file=project_root + "/models.yaml", credentials_file=project_root + "/credentials.yaml")
 
         # response = gen.generate("Hello, nice to meet you", model_name="openai/gpt-4o-2024-08-06")
         # self.assertIsNotNone(response)
         # print("GPT-4o: Worked")
-        # response = gen.generate("Hello, nice to meet you", model_name="deepseek/deepseek-chat")
+        # response = gen.generate("Hello, nice to meet you", model_name="deepseek/deepseek-v4-flash")
         # self.assertIsNotNone(response)
         # print("DeepSeek-Chat: Worked")
         # response = gen.generate("Hello, nice to meet you", model_name="anthropic/claude-3-7-sonnet-20250219")

--- a/projects/llmeo/tests/test_cli.py
+++ b/projects/llmeo/tests/test_cli.py
@@ -53,7 +53,7 @@ class TestCLIFunctionality(unittest.TestCase):
             common_args.add_argument("--max-tokens", type=int, default=8000)
             common_args.add_argument("--iterations", type=int, default=2)
             common_args.add_argument("--seed", type=int, default=42)
-            common_args.add_argument("--model", type=str, default="deepseek/deepseek-chat")
+            common_args.add_argument("--model", type=str, default="deepseek/deepseek-v4-flash")
             common_args.add_argument("--temperature", type=float, default=1)
             
             few_shot_parser = subparsers.add_parser("few-shot", parents=[common_args])
@@ -86,7 +86,7 @@ class TestCLIFunctionality(unittest.TestCase):
         common_args.add_argument("--max-tokens", type=int, default=8000)
         common_args.add_argument("--iterations", type=int, default=2)
         common_args.add_argument("--seed", type=int, default=42)
-        common_args.add_argument("--model", type=str, default="deepseek/deepseek-chat")
+        common_args.add_argument("--model", type=str, default="deepseek/deepseek-v4-flash")
         common_args.add_argument("--temperature", type=float, default=1)
         
         single_prop_parser = subparsers.add_parser("single-prop", parents=[common_args])
@@ -117,7 +117,7 @@ class TestCLIFunctionality(unittest.TestCase):
         common_args.add_argument("--max-tokens", type=int, default=8000)
         common_args.add_argument("--iterations", type=int, default=2)
         common_args.add_argument("--seed", type=int, default=42)
-        common_args.add_argument("--model", type=str, default="deepseek/deepseek-chat")
+        common_args.add_argument("--model", type=str, default="deepseek/deepseek-v4-flash")
         common_args.add_argument("--temperature", type=float, default=1)
         
         multi_prop_parser = subparsers.add_parser("multi-prop", parents=[common_args])
@@ -139,7 +139,7 @@ class TestCLIFunctionality(unittest.TestCase):
         common_args.add_argument("--max-tokens", type=int, default=8000)
         common_args.add_argument("--iterations", type=int, default=2)
         common_args.add_argument("--seed", type=int, default=42)
-        common_args.add_argument("--model", type=str, default="deepseek/deepseek-chat")
+        common_args.add_argument("--model", type=str, default="deepseek/deepseek-v4-flash")
         common_args.add_argument("--temperature", type=float, default=1)
         
         few_shot_parser = subparsers.add_parser("few-shot", parents=[common_args])
@@ -151,7 +151,7 @@ class TestCLIFunctionality(unittest.TestCase):
         self.assertEqual(args.max_tokens, 8000)
         self.assertEqual(args.iterations, 2)
         self.assertEqual(args.seed, 42)
-        self.assertEqual(args.model, "deepseek/deepseek-chat")
+        self.assertEqual(args.model, "deepseek/deepseek-v4-flash")
         self.assertEqual(args.temperature, 1)
 
     @patch('cli.run_few_shot')
@@ -279,7 +279,7 @@ class TestCLIFunctionality(unittest.TestCase):
         common_args.add_argument("--max-tokens", type=int, default=8000)
         common_args.add_argument("--iterations", type=int, default=2)
         common_args.add_argument("--seed", type=int, default=42)
-        common_args.add_argument("--model", type=str, default="deepseek/deepseek-chat")
+        common_args.add_argument("--model", type=str, default="deepseek/deepseek-v4-flash")
         common_args.add_argument("--temperature", type=float, default=1)
         
         few_shot_parser = subparsers.add_parser("few-shot", parents=[common_args])


### PR DESCRIPTION
## Summary
- refresh the LLMEO README with current setup, data download, model config, run, output, and troubleshooting instructions
- add a DeepSeek V4-Flash model template config with thinking disabled for OpenAI-compatible calls
- lazy-load LLMEO CLI runtime imports and align defaults/tests with the current DeepSeek model
- pin LLMEO runtime dependencies that drifted into Python 3.10 incompatibilities (`litellm`, `transformers`, `tokenizers`)
- make Weave logging best-effort/offline by default so `python test.py` and local CLI runs do not require W&B network access
- fix the legacy `test.py` harness-root path so it resolves root `models.yaml`/`credentials.yaml` correctly

## Validation
- `python cli.py`
- `python cli.py --help`
- `python test.py`
- `python -m pytest -q`
- `WEAVE_DISABLED=true python cli.py few-shot --iterations 1 --samples 1 --num-samples 1 --temperature 0`